### PR TITLE
Minor fix to SliceType values to render correct view

### DIFF
--- a/src/ipyniivue/_constants.py
+++ b/src/ipyniivue/_constants.py
@@ -8,11 +8,11 @@ __all__ = [
 
 
 class SliceType(enum.Enum):
-    AXIAL = 1
-    CORONAL = 2
-    SAGITTAL = 3
-    MULTIPLANAR = 4
-    RENDER = 5
+    AXIAL = 0
+    CORONAL = 1
+    SAGITTAL = 2
+    MULTIPLANAR = 3
+    RENDER = 4
 
 
 class DragMode(enum.Enum):


### PR DESCRIPTION
I changed the SliceType enum values in src/ipyniivue/_constants.py to work and match NiiVue.

In the original NiiVue code, SLICE_TYPE is defined with the following:
```
export enum SLICE_TYPE {
  AXIAL = 0,
  CORONAL = 1,
  SAGITTAL = 2,
  MULTIPLANAR = 3,
  RENDER = 4
}
```

but was carried over to ipyniivue as:
```
class SliceType(enum.Enum):
    AXIAL = 1
    CORONAL = 2
    SAGITTAL = 3
    MULTIPLANAR = 4
    RENDER = 5
```

As a result, the command nv.slice_type = SliceType.AXIAL will set a Coronal view, the command nv.slice_type = SliceType.CORONAL will set a Sagittal view, and so on. This change will fix that.