### PR TITLE
added frame4d and example

### DIFF
--- a/examples/example_4d.ipynb
+++ b/examples/example_4d.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "094d7d78-087b-4eeb-963a-186d1653b582",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import ipyniivue\n",
+    "from ipyniivue import NiiVue, SliceType, download_dataset\n",
+    "\n",
+    "# GitHub API URL for the base folder\n",
+    "BASE_API_URL = (\n",
+    "    \"https://api.github.com/repos/niivue/niivue/contents/packages/niivue/demos/images\"\n",
+    ")\n",
+    "DATA_FOLDER = Path(ipyniivue.__file__).parent / \"images\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0825cf6b-a0c7-43aa-8103-4233fcf5905d",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Downloads all data for examples\n",
+    "download_dataset(f\"{BASE_API_URL}\", DATA_FOLDER)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "7a0f574e-81f1-4b71-8b8a-94c4b0bfbf80",
+   "metadata": {},
+   "source": [
+    "nibabel isn't currently in the ipyniivue requirements, so you might need to install it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b3eccef-0caa-4948-a2ed-fa6000150d35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install nibabel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7332152b-1073-4112-a231-a04d402ae2d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nibabel as nib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1368792b-7ae3-4a61-80c2-aa3f8a0c9984",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66143d2b-af3a-4fcf-9d0c-b5c7ff19931d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example = DATA_FOLDER / 'mpld_asl.nii.gz'\n",
+    "volumes = [\n",
+    "    {\n",
+    "        \"path\": example,\n",
+    "        \"colormap\": \"gray\",\n",
+    "        \"visible\": True,\n",
+    "        \"opacity\": 1.0,\n",
+    "    },\n",
+    "]\n",
+    "nv = NiiVue(slice_type=SliceType.MULTIPLANAR)\n",
+    "nv.load_volumes(volumes)\n",
+    "\n",
+    "nvols = nib.load(example).shape[-1]\n",
+    "\n",
+    "slider = widgets.IntSlider(min = 0, max=nvols-1, description='Volume')\n",
+    "\n",
+    "def update_frame(*args):\n",
+    "    nv.volumes[0].frame4D = slider.value\n",
+    "\n",
+    "slider.observe(update_frame, 'value')\n",
+    "\n",
+    "display(slider)\n",
+    "display(nv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e19c11d-91f0-4075-b6a3-37d9ccef8204",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/js/types.ts
+++ b/js/types.ts
@@ -13,6 +13,7 @@ export type VolumeModel = { model_id: string } & AnyModel<{
 	colorbar_visible: boolean;
 	cal_min?: number;
 	cal_max?: number;
+	frame4D: number;
 }>;
 
 interface MeshLayer {

--- a/js/volume.ts
+++ b/js/volume.ts
@@ -23,7 +23,7 @@ function create_volume(
 		undefined, // ignoreZeroVoxels
 		undefined, // useQFormNotSForm
 		undefined, // colormapNegative
-		undefined, // frame4D
+		vmodel.get("frame4D"), // frame4D
 		undefined, // imageType
 		undefined, // cal_minNeg
 		undefined, // cal_maxNeg
@@ -50,11 +50,19 @@ function create_volume(
 		volume.opacity = vmodel.get("opacity");
 		nv.updateGLVolume();
 	}
+	function frame4D_changed() {
+		volume.frame4D = vmodel.get("frame4D");
+		nv.updateGLVolume();
+	}
+	
+
+
 	vmodel.on("change:colorbar_visible", colorbar_visible_changed);
 	vmodel.on("change:cal_min", cal_min_changed);
 	vmodel.on("change:cal_max", cal_max_changed);
 	vmodel.on("change:colormap", colormap_changed);
 	vmodel.on("change:opacity", opacity_changed);
+	vmodel.on("change:frame4D", frame4D_changed);
 	return [
 		volume,
 		() => {
@@ -63,6 +71,7 @@ function create_volume(
 			vmodel.off("change:cal_max", cal_max_changed);
 			vmodel.off("change:colormap", colormap_changed);
 			vmodel.off("change:opacity", opacity_changed);
+			vmodel.off("change:frame4D", frame4D_changed);
 		},
 	];
 }

--- a/src/ipyniivue/widget.py
+++ b/src/ipyniivue/widget.py
@@ -59,6 +59,7 @@ class Volume(ipywidgets.Widget):
     colorbar_visible = t.Bool(True).tag(sync=True)
     cal_min = t.Float(None, allow_none=True).tag(sync=True)
     cal_max = t.Float(None, allow_none=True).tag(sync=True)
+    frame4D = t.Int(0).tag(sync=True)
 
 
 class Drawing(ipywidgets.Widget):
@@ -76,7 +77,6 @@ class Drawing(ipywidgets.Widget):
     opacity = t.Float(1.0).tag(sync=True)
     colormap = t.List([0, 0, 0, 0]).tag(sync=True)
     colorbar_visible = t.Bool(True).tag(sync=True)
-
 
 class NiiVue(OptionsMixin, anywidget.AnyWidget):
     """


### PR DESCRIPTION
I created an example 4d volume browsing widget. This required adding the "frame4D" parameter -- I just copied what was done for "colormap" and "opacity". It uses nibabel to get the dimensions of the nifti file, but this could be replaced by a method to get the dimensions of the currently loaded niivue volume (this method surely exists but I haven't found it yet).