### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix a typo

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,11 @@ repos:
         args:
           - --remove-empty-cells
           - --
+  
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in pyproject.toml
+    rev: v2.4.1
+    hooks:
+    - id: codespell
+    additional_dependencies:
+    - tomli  # for python_version < '3.11'

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -18,7 +18,7 @@ run the following command:
 
 As a result, the hooks will automatically check and fix some issues before
 pushing with git. If changes are made after committing with git, you will need
-to commit again afterwords. Alternatively, you can just run the following
+to commit again afterwards. Alternatively, you can just run the following
 command beforehand:
 
 .. code-block:: console

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,5 +66,5 @@ select = [
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = '.git*,package-lock.json'
 check-hidden = true
-ignore-regex = '^\s*"image/\S+": ".*'
+ignore-regex = '^\s*"image/\S+": ".*|.{200,}'
 # ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,10 @@ select = [
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["D", "S"]
 "scripts/*.py" = ["D", "S"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,package-lock.json'
+check-hidden = true
+ignore-regex = '^\s*"image/\S+": ".*'
+# ignore-words-list = ''


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

Just a single typo so may be "not worth it"? ;)