### PR TITLE
Replace use of `.model_id` with `id` traitlet

### DIFF
--- a/js/lib.ts
+++ b/js/lib.ts
@@ -1,6 +1,5 @@
 import type { AnyModel } from "@anywidget/types";
-import * as nv from "@niivue/niivue";
-import type { Model } from "./types.ts";
+import type { Model, VolumeModel } from "./types.ts";
 
 /**
  * Generates a unique file name for a volume (using the model id and the volume path)
@@ -9,13 +8,9 @@ import type { Model } from "./types.ts";
  * to the volume sent from Python. This function generates a new filename for the volume
  * using the existing filename and model
  */
-export function unique_id(model: {
-	model_id: string;
-	get(name: "path"): { name: string };
-}): string {
-	const path = model.get("path");
-	// take the first 6 characters of the model_id, it should be unique enough
-	const id = model.model_id.slice(0, 6);
+export function unique_id(vmodel: VolumeModel): string {
+	const id = vmodel.get("id");
+	const path = vmodel.get("path");
 	return `${id}:${path.name}`;
 }
 

--- a/js/types.ts
+++ b/js/types.ts
@@ -5,7 +5,7 @@ interface File {
 	data: DataView;
 }
 
-export type VolumeModel = { model_id: string } & AnyModel<{
+export type VolumeModel = AnyModel<{
 	path: File;
 	id: string;
 	colormap: string;
@@ -27,7 +27,7 @@ interface MeshLayer {
 	cal_max?: number;
 }
 
-export type MeshModel = { model_id: string } & AnyModel<{
+export type MeshModel = AnyModel<{
 	path: File;
 	id: string;
 	rgba255: Array<number>;


### PR DESCRIPTION
`.model_id` is not part of the [`AnyModel` interface](https://anywidget.dev/en/afm/#model-interface) and is only available in Jupyter-based environments. This updates the code to use the user-defined (readonly) `id` traitlet on the model instead, improving compatibility with non-Jupyter environments like [marimo](https://marimo.io)

in marimo: 





https://github.com/user-attachments/assets/b482a2ce-66e9-454b-990f-9b69be9f2888



