### PR TITLE
Persisting nv obj + canvas

### DIFF
--- a/examples/basic_multiplanar.ipynb
+++ b/examples/basic_multiplanar.ipynb
@@ -103,15 +103,6 @@
    "source": [
     "nv"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nv.id"
-   ]
   }
  ],
  "metadata": {

--- a/js/widget.ts
+++ b/js/widget.ts
@@ -5,6 +5,54 @@ import { Disposer } from "./lib.ts";
 import { render_meshes } from "./mesh.ts";
 import { render_volumes } from "./volume.ts";
 
+// Attach model event handlers
+function attachModelEventHandlers(
+	nv: niivue.Niivue,
+	model: Model,
+	disposer: Disposer,
+) {
+	model.on("change:_volumes", () => render_volumes(nv, model, disposer));
+	model.on("change:_meshes", () => render_meshes(nv, model, disposer));
+
+	// Any time we change the options, we need to update the nv gl
+	model.on("change:_opts", () => {
+		nv.document.opts = { ...nv.opts, ...model.get("_opts") };
+		nv.updateGLVolume();
+	});
+
+	// Handle any message directions from the nv object.
+	model.on("msg:custom", (payload: CustomMessagePayload) => {
+		const { type, data } = payload;
+		switch (type) {
+			case "save_document": {
+				const { fileName, compress } = data;
+				nv.saveDocument(fileName, compress);
+				break;
+			}
+			case "save_html": {
+				const { fileName, canvasId } = data;
+				// Note: currently fails as esm is inaccesbile.
+				// nv.saveHTML(fileName, canvasId, esm);
+				break;
+			}
+			case "save_image": {
+				const { fileName, saveDrawing, indexVolume } = data;
+				nv.saveImage({
+					filename: fileName,
+					isSaveDrawing: saveDrawing,
+					volumeByIndex: indexVolume,
+				});
+				break;
+			}
+			case "save_scene": {
+				const { fileName } = data;
+				nv.saveScene(fileName);
+				break;
+			}
+		}
+	});
+}
+
 // Attach Niivue event handlers
 function attachNiivueEventHandlers(nv: niivue.Niivue, model: Model) {
 	nv.onImageLoaded = async (volume: niivue.NVImage) => {
@@ -272,55 +320,19 @@ export default {
 		const nv = new niivue.Niivue(model.get("_opts") ?? {});
 		nv.attachToCanvas(canvas);
 
+		// Attach model event handlers
+		attachModelEventHandlers(nv, model, disposer);
+
 		// Attach niivue event handlers
 		attachNiivueEventHandlers(nv, model);
 
 		await render_volumes(nv, model, disposer);
-		model.on("change:_volumes", () => render_volumes(nv, model, disposer));
 		await render_meshes(nv, model, disposer);
-		model.on("change:_meshes", () => render_meshes(nv, model, disposer));
 
 		nv.createEmptyDrawing();
 
-		// Any time we change the options, we need to update the nv gl
-		model.on("change:_opts", () => {
-			nv.document.opts = { ...nv.opts, ...model.get("_opts") };
-			nv.updateGLVolume();
-		});
 		model.on("change:height", () => {
 			container.style.height = `${model.get("height")}px`;
-		});
-
-		// Handle any message directions from the nv object.
-		model.on("msg:custom", (payload: CustomMessagePayload) => {
-			const { type, data } = payload;
-			switch (type) {
-				case "save_document": {
-					const { fileName, compress } = data;
-					nv.saveDocument(fileName, compress);
-					break;
-				}
-				case "save_html": {
-					const { fileName, canvasId } = data;
-					// Note: currently fails as esm is inaccesbile.
-					// nv.saveHTML(fileName, canvasId, esm);
-					break;
-				}
-				case "save_image": {
-					const { fileName, saveDrawing, indexVolume } = data;
-					nv.saveImage({
-						filename: fileName,
-						isSaveDrawing: saveDrawing,
-						volumeByIndex: indexVolume,
-					});
-					break;
-				}
-				case "save_scene": {
-					const { fileName } = data;
-					nv.saveScene(fileName);
-					break;
-				}
-			}
 		});
 
 		// All the logic for cleaning up the event listeners and the nv object

--- a/js/widget.ts
+++ b/js/widget.ts
@@ -5,17 +5,29 @@ import { Disposer } from "./lib.ts";
 import { render_meshes } from "./mesh.ts";
 import { render_volumes } from "./volume.ts";
 
+// store all nv objects for the page
+const nvMap = new Map<string, niivue.Niivue>();
+
 // Attach model event handlers
 function attachModelEventHandlers(
 	nv: niivue.Niivue,
 	model: Model,
 	disposer: Disposer,
 ) {
-	model.on("change:_volumes", () => render_volumes(nv, model, disposer));
-	model.on("change:_meshes", () => render_meshes(nv, model, disposer));
+	model.on("change:_volumes", () => {
+		if (nv.canvas) {
+			render_volumes(nv, model, disposer);
+		}
+	});
+	model.on("change:_meshes", () => {
+		if (nv.canvas) {
+			render_meshes(nv, model, disposer);
+		}
+	});
 
 	// Any time we change the options, we need to update the nv gl
 	model.on("change:_opts", () => {
+		console.log("Updating opts callback");
 		nv.document.opts = { ...nv.opts, ...model.get("_opts") };
 		nv.updateGLVolume();
 	});
@@ -309,16 +321,18 @@ function attachNiivueEventHandlers(nv: niivue.Niivue, model: Model) {
 }
 
 export default {
-	async render({ model, el }: { model: Model; el: HTMLElement }) {
+	async initialize({ model }: { model: Model }) {
+		let id = model.get("id");
+		console.log("Initializing called on model:", id);
 		const disposer = new Disposer();
-		const canvas = document.createElement("canvas");
-		const container = document.createElement("div");
-		container.style.height = `${model.get("height")}px`;
-		container.appendChild(canvas);
-		el.appendChild(container);
 
-		const nv = new niivue.Niivue(model.get("_opts") ?? {});
-		nv.attachToCanvas(canvas);
+		let nv = nvMap.get(model.get("id"));
+
+		if (!nv) {
+			console.log("Creating new Niivue instance");
+			nv = new niivue.Niivue(model.get("_opts") ?? {});
+			nvMap.set(model.get("id"), nv);
+		}
 
 		// Attach model event handlers
 		attachModelEventHandlers(nv, model, disposer);
@@ -326,23 +340,74 @@ export default {
 		// Attach niivue event handlers
 		attachNiivueEventHandlers(nv, model);
 
-		await render_volumes(nv, model, disposer);
-		await render_meshes(nv, model, disposer);
-
-		nv.createEmptyDrawing();
-
-		model.on("change:height", () => {
-			container.style.height = `${model.get("height")}px`;
-		});
-
-		// All the logic for cleaning up the event listeners and the nv object
+		// Logic for cleaning up the event listeners and the nv object
 		return () => {
 			disposer.disposeAll();
+
 			model.off("change:_volumes");
 			model.off("change:_meshes");
 			model.off("change:_opts");
 			model.off("change:height");
 			model.off("msg:custom");
+
+			// remove the nv instance
+			nvMap.delete(model.get("id"));
+		};
+	},
+	async render({ model, el }: { model: Model; el: HTMLElement }) {
+		const nv = nvMap.get(model.get("id"));
+		if (!nv) {
+			console.error("Niivue instance not found for model", model.get("id"));
+			return;
+		}
+
+		const disposer = new Disposer();
+
+		if (!nv.canvas?.parentNode) {
+			console.log("drawing first render");
+
+			// Create a container div and set its height
+			const container = document.createElement("div");
+			container.style.height = `${model.get("height")}px`;
+			el.appendChild(container);
+
+			// Create a new canvas and attach it to the container
+			const canvas = document.createElement("canvas");
+			container.appendChild(canvas);
+
+			// Handle height changes
+			model.on("change:height", () => {
+				container.style.height = `${model.get("height")}px`;
+			});
+
+			// Attach nv to canvas
+			nv.attachToCanvas(canvas);
+
+			// Load initial volumes and meshes
+			await render_volumes(nv, model, disposer);
+			await render_meshes(nv, model, disposer);
+
+			// Drawing setup
+			nv.createEmptyDrawing();
+		} else {
+			console.log("moving render around");
+
+			// Ensure the canvas is attached to the container
+			if (nv.canvas.parentNode?.parentNode) {
+				nv.canvas.parentNode.parentNode.removeChild(nv.canvas.parentNode);
+			}
+
+			// Attach
+			el.appendChild(nv.canvas.parentNode);
+		}
+
+		// Return cleanup function, runs when page reloaded or cell run again
+		return () => {
+			// only want to run disposer when nv widget is removed, not when it is re-displayed
+
+			if (nv.canvas?.parentNode?.parentNode) {
+				nv.canvas.parentNode.parentNode.removeChild(nv.canvas.parentNode);
+			}
 		};
 	},
 };


### PR DESCRIPTION
Prevent re-nv-initialization + re-rendering = speed boost!

When each new cell is run, the render function in widget.ts gets called. Previously, this meant that each new cell (that ran display(nv) ) meant a new nv object. We can see this occurring actually, as the volume ids would change on each render:
> \*this is from the js console of the **basic_multiplanar.ipynb** example
<img width="536" alt="old-min" src="https://github.com/user-attachments/assets/15e56686-34d3-462c-b936-bb978a9bd389" />
Notice the difference in the old frontend volume ids and new frontend volume ids. They're different because the nv objects are different and the volumes are re-added. Instead of re-adding the volumes, if we've already created the nv object and rendered it somewhere, why don't we reuse that?

That's what this PR does, which also brings a bit of a speed boost:
<img width="536" alt="new-min" src="https://github.com/user-attachments/assets/1287cf10-6310-4458-973c-d51b41a6da9d" />

Notice the "moving render around" console.log statement, which now occurs **instead** of re-rendering the volumes and meshes. 

Also, importantly, the nv object is tied to the widget model. You can see the initialization log for nv at the top.


