### PR TITLE
Add support for colormaps, colormaps.mesh, mask, and mesh.4d notebooks

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import * as niivue from "@niivue/niivue";
+import esbuild from "esbuild";
+
+global.window = {};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const generateColormapsPlugin = {
+	name: "generate-colormaps",
+	setup(build) {
+		build.onEnd((result) => {
+			if (result?.errors?.length === 0) {
+				const nv = new niivue.Niivue();
+				const colormapNames = nv.colormaps();
+				const colormapsTxtContent = colormapNames.join("\n");
+
+				const outputPath = path.join(
+					__dirname,
+					"src",
+					"ipyniivue",
+					"static",
+					"colormaps.txt",
+				);
+
+				fs.writeFileSync(outputPath, colormapsTxtContent, "utf8");
+				console.log("Successfully generated colormaps.txt.");
+			} else {
+				console.error("Build failed, colormaps.txt not generated.");
+			}
+		});
+	},
+};
+
+const generateShaderNamesPlugin = {
+	name: "generate-shader-names",
+	setup(build) {
+		build.onEnd((result) => {
+			if (result?.errors?.length === 0) {
+				const nv = new niivue.Niivue();
+				const shaderNames = nv.meshShaderNames();
+				const shaderNamesTxtContent = shaderNames.join("\n");
+
+				const outputPath = path.join(
+					__dirname,
+					"src",
+					"ipyniivue",
+					"static",
+					"meshShaderNames.txt",
+				);
+
+				fs.writeFileSync(outputPath, shaderNamesTxtContent, "utf8");
+				console.log("Successfully generated meshShaderNames.txt.");
+			} else {
+				console.error("Build failed, meshShaderNames.txt not generated.");
+			}
+		});
+	},
+};
+
+async function build(isWatchMode) {
+	const buildOptions = {
+		entryPoints: ["js/widget.ts"],
+		bundle: true,
+		outfile: "src/ipyniivue/static/widget.js",
+		plugins: [generateColormapsPlugin, generateShaderNamesPlugin],
+		format: "esm",
+	};
+
+	if (isWatchMode) {
+		const ctx = await esbuild.context(buildOptions);
+		await ctx.watch();
+		console.log("Watching for changes...");
+	} else {
+		await esbuild.build(buildOptions).catch(() => process.exit(1));
+	}
+}
+
+const isWatchMode = process.argv.includes("--watch");
+
+build(isWatchMode).catch((e) => {
+	console.error(e);
+	process.exit(1);
+});

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -25,8 +25,3 @@ API Documentation
    :members:
    :undoc-members:
    :show-inheritance:
-
-.. autoclass:: ipyniivue.options_mixin.OptionsMixin
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -39,6 +39,8 @@ All commands are run from the root of the project, from a terminal:
 +--------------------+-----------------------------------+
 | $ hatch run test   | Run unit tests with pytest        |
 +--------------------+-----------------------------------+
+| $ hatch run docs   | Build docs with  Sphinx           |
++--------------------+-----------------------------------+
 
 Alternatively, you can develop ipyniivue by manually creating a virtual environment and managing installation and dependencies with pip.
 

--- a/docs/source/enums.rst
+++ b/docs/source/enums.rst
@@ -1,0 +1,24 @@
+Enums
+=====
+
+.. currentmodule:: ipyniivue.constants
+
+.. autoclass:: DragMode
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: MultiplanarType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: SliceType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: ShowRender
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,11 +3,12 @@ IPyNiiVue Documentation
 
 A Jupyter Widget for Niivue based on anywidget.
 
-
 .. toctree::
     :maxdepth: 4
     :caption: Contents:
 
     install
     api
+    options
+    enums
     contributing

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -1,0 +1,7 @@
+Options
+=======
+
+.. autoclass:: ipyniivue.options_mixin.OptionsMixin
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/examples/add_from_frontend.ipynb
+++ b/examples/add_from_frontend.ipynb
@@ -83,7 +83,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/additive_voxels.ipynb
+++ b/examples/additive_voxels.ipynb
@@ -100,7 +100,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/basic_multiplanar.ipynb
+++ b/examples/basic_multiplanar.ipynb
@@ -120,7 +120,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/colormaps.ipynb
+++ b/examples/colormaps.ipynb
@@ -1,0 +1,378 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "49803495-6d35-450f-9549-4b05bec1d8eb",
+   "metadata": {},
+   "source": [
+    "# Colormaps\n",
+    "This is a demo that replicates all the functionality displayed in https://niivue.github.io/niivue/features/colormaps.html."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d2a0480-9705-4857-91e4-1c8e2419218c",
+   "metadata": {},
+   "source": [
+    "Prepare images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a829351-483b-4787-86c3-3cdbf74084bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import ipyniivue\n",
+    "\n",
+    "# GitHub API URL for the base folder\n",
+    "BASE_API_URL = (\n",
+    "    \"https://api.github.com/repos/niivue/niivue/contents/packages/niivue/demos/images\"\n",
+    ")\n",
+    "DATA_FOLDER = Path(ipyniivue.__file__).parent / \"images\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1660119c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download data for example\n",
+    "ipyniivue.download_dataset(\n",
+    "    f\"{BASE_API_URL}\",\n",
+    "    DATA_FOLDER,\n",
+    "    files=[\n",
+    "        \"mni152.nii.gz\",\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f0d7c6f-ac00-420d-b298-1a83d802a250",
+   "metadata": {},
+   "source": [
+    "install and import the necessary libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea6579ac-916f-4464-98c3-e8fc8b550c82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import math\n",
+    "\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import clear_output, display\n",
+    "\n",
+    "from ipyniivue import NiiVue"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52f4c48c-7a3e-48e0-848c-b16cff8b9d74",
+   "metadata": {},
+   "source": [
+    "Create an instance of NiiVue and load the volume"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "946e877b-0911-4a4a-b08c-b86e17f0d554",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create NiiVue instance\n",
+    "nv = NiiVue(back_color=(0.3, 0.3, 0.3, 1))\n",
+    "\n",
+    "nv.load_volumes(\n",
+    "    [\n",
+    "        {\n",
+    "            \"path\": DATA_FOLDER / \"mni152.nii.gz\",\n",
+    "            \"colormap\": \"gray\",\n",
+    "            \"opacity\": 1,\n",
+    "            \"visible\": True,\n",
+    "        }\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "nv.is_colorbar = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a6d4b73-2b47-413b-b77b-59644f375fde",
+   "metadata": {},
+   "source": [
+    "create the interactive controls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a817f70-fd0f-4709-a96b-80eef3c91ea3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Invert Checkbox\n",
+    "invert_check = widgets.Checkbox(value=False, description=\"Invert\")\n",
+    "\n",
+    "\n",
+    "def on_invert_change(change):\n",
+    "    \"\"\"Set colormap invert.\"\"\"\n",
+    "    nv.volumes[0].colormap_invert = change[\"new\"]\n",
+    "\n",
+    "\n",
+    "invert_check.observe(on_invert_change, names=\"value\")\n",
+    "\n",
+    "# Green Dragging Selection Checkbox\n",
+    "select_check = widgets.Checkbox(value=False, description=\"Green Dragging Selection\")\n",
+    "\n",
+    "\n",
+    "def on_select_change(change):\n",
+    "    \"\"\"Set selection box color.\"\"\"\n",
+    "    if change[\"new\"]:\n",
+    "        nv.set_selection_box_color((0, 1, 0, 0.7))\n",
+    "    else:\n",
+    "        nv.set_selection_box_color((1, 1, 1, 0.5))\n",
+    "\n",
+    "\n",
+    "select_check.observe(on_select_change, names=\"value\")\n",
+    "\n",
+    "# Green Crosshairs Checkbox\n",
+    "cross_check = widgets.Checkbox(value=False, description=\"Green Crosshairs\")\n",
+    "\n",
+    "\n",
+    "def on_cross_change(change):\n",
+    "    \"\"\"Set crosshair color.\"\"\"\n",
+    "    if change[\"new\"]:\n",
+    "        nv.set_crosshair_color((0, 1, 0, 1))\n",
+    "    else:\n",
+    "        nv.set_crosshair_color((1, 0, 0, 1))\n",
+    "\n",
+    "\n",
+    "cross_check.observe(on_cross_change, names=\"value\")\n",
+    "\n",
+    "# Wide Crosshairs Checkbox\n",
+    "wide_check = widgets.Checkbox(value=False, description=\"Wide Crosshairs\")\n",
+    "\n",
+    "\n",
+    "def on_wide_change(change):\n",
+    "    \"\"\"Set crosshair width.\"\"\"\n",
+    "    if change[\"new\"]:\n",
+    "        nv.set_crosshair_width(3)\n",
+    "    else:\n",
+    "        nv.set_crosshair_width(1)\n",
+    "\n",
+    "\n",
+    "wide_check.observe(on_wide_change, names=\"value\")\n",
+    "\n",
+    "# Gamma Slider\n",
+    "gamma_slider = widgets.IntSlider(\n",
+    "    value=100,\n",
+    "    min=10,\n",
+    "    max=400,\n",
+    "    step=10,\n",
+    "    description=\"Gamma\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def on_gamma_change(change):\n",
+    "    \"\"\"Set gamma.\"\"\"\n",
+    "    nv.set_gamma(change[\"new\"] * 0.01)\n",
+    "\n",
+    "\n",
+    "gamma_slider.observe(on_gamma_change, names=\"value\")\n",
+    "\n",
+    "# Save Bitmap Button\n",
+    "save_bmp_button = widgets.Button(description=\"Save Bitmap\")\n",
+    "\n",
+    "\n",
+    "def on_save_bmp_clicked(b):\n",
+    "    \"\"\"Save scene.\"\"\"\n",
+    "    nv.save_scene(\"ScreenShot.png\")\n",
+    "    with out:\n",
+    "        clear_output(wait=True)\n",
+    "        print(\"Scene saved as 'ScreenShot.png'\")\n",
+    "\n",
+    "\n",
+    "save_bmp_button.on_click(on_save_bmp_clicked)\n",
+    "\n",
+    "# Output widget for messages\n",
+    "out = widgets.Output()\n",
+    "\n",
+    "# Organize header controls\n",
+    "header_controls = widgets.VBox(\n",
+    "    [\n",
+    "        invert_check,\n",
+    "        select_check,\n",
+    "        cross_check,\n",
+    "        wide_check,\n",
+    "        gamma_slider,\n",
+    "        save_bmp_button,\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "644efbee-68ea-420d-b3f8-3cdf79d0dbe9",
+   "metadata": {},
+   "source": [
+    "Create the colormap buttons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e473b27b-9299-45d1-8105-0bfbe1fe7371",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get available colormaps\n",
+    "colormaps = nv.colormaps()\n",
+    "colormap_buttons = []\n",
+    "\n",
+    "\n",
+    "def create_colormap_button(name):\n",
+    "    \"\"\"Create a colormap button.\"\"\"\n",
+    "    btn = widgets.Button(description=name)\n",
+    "\n",
+    "    def on_click(b):\n",
+    "        nv.set_colormap(nv.volumes[0].id, name)\n",
+    "\n",
+    "    btn.on_click(on_click)\n",
+    "    return btn\n",
+    "\n",
+    "\n",
+    "colormap_buttons = [create_colormap_button(name) for name in colormaps]\n",
+    "\n",
+    "# Organize colormap buttons in a grid\n",
+    "num_cols = 10\n",
+    "num_rows = math.ceil(len(colormap_buttons) / num_cols)\n",
+    "colormap_grid = []\n",
+    "\n",
+    "for i in range(num_rows):\n",
+    "    row_buttons = colormap_buttons[i * num_cols : (i + 1) * num_cols]\n",
+    "    colormap_grid.append(widgets.HBox(row_buttons))\n",
+    "\n",
+    "colormap_buttons_widget = widgets.VBox(colormap_grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba2bf693-2add-4eed-913c-21f8b6cc6962",
+   "metadata": {},
+   "source": [
+    "Create the custom colormap input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35d42e8f-4a35-4e62-b772-642010d033cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Custom Colormap TextArea\n",
+    "cmap_textarea = widgets.Textarea(\n",
+    "    value=\"\"\"{\n",
+    "  \"R\": [0, 255, 0],\n",
+    "  \"G\": [0, 0, 255],\n",
+    "  \"B\": [0, 0, 0],\n",
+    "  \"A\": [0, 64, 64],\n",
+    "  \"I\": [0, 85, 255]\n",
+    "}\"\"\",\n",
+    "    description=\"Custom Colormap\",\n",
+    "    layout=widgets.Layout(width=\"60%\", height=\"100px\"),\n",
+    ")\n",
+    "\n",
+    "# Custom Colormap Button\n",
+    "custom_button = widgets.Button(description=\"Custom\")\n",
+    "\n",
+    "\n",
+    "def on_custom_clicked(b):\n",
+    "    \"\"\"Add the custom colormap to nv.\"\"\"\n",
+    "    try:\n",
+    "        cmap = json.loads(cmap_textarea.value)\n",
+    "        key = \"Custom\"\n",
+    "        nv.add_colormap(key, cmap)\n",
+    "        nv.set_colormap(nv.volumes[0].id, key)\n",
+    "    except json.JSONDecodeError:\n",
+    "        with out:\n",
+    "            clear_output(wait=True)\n",
+    "            print(\"Invalid JSON in custom colormap\")\n",
+    "\n",
+    "\n",
+    "custom_button.on_click(on_custom_clicked)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f27b7c97-1216-452d-b5b0-58a4404cb3f9",
+   "metadata": {},
+   "source": [
+    "Display everything"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8a673e8-6e8a-48d2-a276-a36429129def",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display header controls\n",
+    "display(header_controls)\n",
+    "\n",
+    "display(nv)\n",
+    "\n",
+    "# Display colormap buttons\n",
+    "display(colormap_buttons_widget)\n",
+    "\n",
+    "# Display custom colormap option\n",
+    "display(widgets.HBox([cmap_textarea, custom_button]))\n",
+    "\n",
+    "# Display for prints\n",
+    "display(out)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/colormaps.mesh.ipynb
+++ b/examples/colormaps.mesh.ipynb
@@ -1,0 +1,298 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3f68cd5d-4213-44e2-b1db-fae4bebb7a5d",
+   "metadata": {},
+   "source": [
+    "Prepare images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c36ea7c1-438a-462e-b796-92c586424af8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import ipyniivue\n",
+    "\n",
+    "# GitHub API URL for the base folder\n",
+    "BASE_API_URL = (\n",
+    "    \"https://api.github.com/repos/niivue/niivue/contents/packages/niivue/demos/images\"\n",
+    ")\n",
+    "DATA_FOLDER = Path(ipyniivue.__file__).parent / \"images\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1149f33-ef1e-4249-821f-e41d0644319e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download data for example\n",
+    "ipyniivue.download_dataset(\n",
+    "    f\"{BASE_API_URL}\",\n",
+    "    DATA_FOLDER,\n",
+    "    files=[\n",
+    "        \"BrainMesh_ICBM152.lh.curv\",\n",
+    "        \"BrainMesh_ICBM152.lh.motor.mz3\",\n",
+    "        \"BrainMesh_ICBM152.lh.mz3\",\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d522f34-35e0-452c-808d-2d45a9ee9c37",
+   "metadata": {},
+   "source": [
+    "Create instance of niivue"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4444b81-5bfe-46cc-af63-f6044d04fb80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipyniivue import NiiVue\n",
+    "\n",
+    "nv = NiiVue(back_color=(0.3, 0.3, 0.3, 1))\n",
+    "\n",
+    "meshLHLayersList1 = [\n",
+    "    {\n",
+    "        \"path\": DATA_FOLDER / \"BrainMesh_ICBM152.lh.curv\",\n",
+    "        \"colormap\": \"gray\",\n",
+    "        \"cal_min\": 0.3,\n",
+    "        \"cal_max\": 0.5,\n",
+    "        \"opacity\": 0.7,\n",
+    "    },\n",
+    "    {\n",
+    "        \"path\": DATA_FOLDER / \"BrainMesh_ICBM152.lh.motor.mz3\",\n",
+    "        \"cal_min\": 1.64,\n",
+    "        \"cal_max\": 5,\n",
+    "        \"colormap\": \"warm\",\n",
+    "        \"colormap_negative\": \"winter\",\n",
+    "        \"use_negative_cmap\": True,\n",
+    "        \"opacity\": 0.7,\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "nv.load_meshes(\n",
+    "    [\n",
+    "        {\n",
+    "            \"path\": DATA_FOLDER / \"BrainMesh_ICBM152.lh.mz3\",\n",
+    "            \"layers\": meshLHLayersList1,\n",
+    "        }\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "nv.is_colorbar = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55820127-9917-4e54-aa48-bf1e169ee4c6",
+   "metadata": {},
+   "source": [
+    "Create interactive widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19ea4d11-94cc-4d7a-ba4d-21e407c18939",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display\n",
+    "\n",
+    "# Invert Checkbox\n",
+    "invert_check = widgets.Checkbox(\n",
+    "    value=False,\n",
+    "    description=\"Invert\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def on_invert_change(change):\n",
+    "    \"\"\"Set mesh layer 1 colormap invert.\"\"\"\n",
+    "    nv.set_mesh_layer_property(nv.meshes[0].id, 1, \"colormap_invert\", change[\"new\"])\n",
+    "\n",
+    "\n",
+    "invert_check.observe(on_invert_change, names=\"value\")\n",
+    "\n",
+    "# Curvature Slider\n",
+    "curve_slider = widgets.IntSlider(\n",
+    "    value=7,\n",
+    "    min=0,\n",
+    "    max=10,\n",
+    "    step=1,\n",
+    "    description=\"Curvature\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def on_curve_slider_change(change):\n",
+    "    \"\"\"Set mesh layer 0 opacity.\"\"\"\n",
+    "    nv.set_mesh_layer_property(nv.meshes[0].id, 0, \"opacity\", change[\"new\"] * 0.1)\n",
+    "\n",
+    "\n",
+    "curve_slider.observe(on_curve_slider_change, names=\"value\")\n",
+    "\n",
+    "# Opacity Slider\n",
+    "opacity_slider = widgets.IntSlider(\n",
+    "    value=7,\n",
+    "    min=0,\n",
+    "    max=10,\n",
+    "    step=1,\n",
+    "    description=\"Opacity\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def on_opacity_slider_change(change):\n",
+    "    \"\"\"Set mesh layer 1 opacity.\"\"\"\n",
+    "    nv.set_mesh_layer_property(nv.meshes[0].id, 1, \"opacity\", change[\"new\"] * 0.1)\n",
+    "\n",
+    "\n",
+    "opacity_slider.observe(on_opacity_slider_change, names=\"value\")\n",
+    "\n",
+    "# Save Bitmap Button\n",
+    "save_bmp_button = widgets.Button(\n",
+    "    description=\"Save Bitmap\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def on_save_bmp_clicked(b):\n",
+    "    \"\"\"Save scene.\"\"\"\n",
+    "    nv.save_scene(\"ScreenShot.png\")\n",
+    "    with out:\n",
+    "        from IPython.display import clear_output\n",
+    "\n",
+    "        clear_output(wait=True)\n",
+    "        print('Scene saved as \"ScreenShot.png\"')\n",
+    "\n",
+    "\n",
+    "save_bmp_button.on_click(on_save_bmp_clicked)\n",
+    "\n",
+    "# Output widget for messages\n",
+    "out = widgets.Output()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25290c1d-4992-45fb-a601-12ae69278856",
+   "metadata": {},
+   "source": [
+    "Create the colormap header buttons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dba89d89-9870-4b5b-943e-b87718b537e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "\n",
+    "# Get available colormaps\n",
+    "colormaps = nv.colormaps()\n",
+    "colormap_buttons = []\n",
+    "\n",
+    "\n",
+    "def create_colormap_button(name):\n",
+    "    \"\"\"Create colormap.\"\"\"\n",
+    "    btn = widgets.Button(description=name)\n",
+    "\n",
+    "    def on_click(b):\n",
+    "        \"\"\"Set mesh layer colormap.\"\"\"\n",
+    "        nv.set_mesh_layer_property(nv.meshes[0].id, 1, \"colormap\", name)\n",
+    "\n",
+    "    btn.on_click(on_click)\n",
+    "    return btn\n",
+    "\n",
+    "\n",
+    "colormap_buttons = [create_colormap_button(name) for name in colormaps]\n",
+    "\n",
+    "# Organize colormap buttons in a grid\n",
+    "num_cols = 10\n",
+    "num_rows = math.ceil(len(colormap_buttons) / num_cols)\n",
+    "colormap_grid = []\n",
+    "\n",
+    "for i in range(num_rows):\n",
+    "    row_buttons = colormap_buttons[i * num_cols : (i + 1) * num_cols]\n",
+    "    colormap_grid.append(widgets.HBox(row_buttons))\n",
+    "\n",
+    "colormap_buttons_widget = widgets.VBox(colormap_grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e53f48a-867b-4195-881b-c800e17ffc90",
+   "metadata": {},
+   "source": [
+    "Display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0dd22c2c-0c0c-4b03-9b56-9af6020b9b60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display header controls\n",
+    "header_controls = widgets.HBox(\n",
+    "    [\n",
+    "        invert_check,\n",
+    "        curve_slider,\n",
+    "        opacity_slider,\n",
+    "        save_bmp_button,\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "display(header_controls)\n",
+    "display(nv)\n",
+    "\n",
+    "# Display footer with colormap buttons\n",
+    "display(colormap_buttons_widget)\n",
+    "\n",
+    "# Print output\n",
+    "display(out)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/drawing.ipynb
+++ b/examples/drawing.ipynb
@@ -132,7 +132,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/example_4d.ipynb
+++ b/examples/example_4d.ipynb
@@ -108,7 +108,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/example_sideview.ipynb
+++ b/examples/example_sideview.ipynb
@@ -116,7 +116,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/mask.ipynb
+++ b/examples/mask.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a7560ca5-f0bc-494d-abb0-477fb3944821",
+   "metadata": {},
+   "source": [
+    "Prepare images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1a27d89-e050-47b9-b959-1fb51e39098e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import ipyniivue\n",
+    "\n",
+    "# GitHub API URL for the base folder\n",
+    "BASE_API_URL = (\n",
+    "    \"https://api.github.com/repos/niivue/niivue/contents/packages/niivue/demos/images\"\n",
+    ")\n",
+    "DATA_FOLDER = Path(ipyniivue.__file__).parent / \"images\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c30f3c8d-28b5-4d0a-9883-a0d22f4f51e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download data for example\n",
+    "ipyniivue.download_dataset(\n",
+    "    f\"{BASE_API_URL}\",\n",
+    "    DATA_FOLDER,\n",
+    "    files=[\n",
+    "        \"fslmean.nii.gz\",\n",
+    "        \"fslt.nii.gz\",\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f91d30c7-3cf5-48e7-97eb-f76ba165eadf",
+   "metadata": {},
+   "source": [
+    "Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67a84d95-df0a-4f24-ad0b-27fc4a724cc3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import necessary libraries\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display\n",
+    "\n",
+    "from ipyniivue import NiiVue, SliceType"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4348595a-6674-48e5-8ef0-04e73332e87c",
+   "metadata": {},
+   "source": [
+    "Create niivue instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1af1bf1b-9033-4fed-800c-856180de5fa4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a NiiVue instance with specific options\n",
+    "# for some reason...show_3d_crosshair doesn't show\n",
+    "nv = NiiVue(show_3d_crosshair=True)\n",
+    "\n",
+    "# Load the volumes\n",
+    "volumes = [\n",
+    "    {\n",
+    "        \"path\": DATA_FOLDER / \"fslmean.nii.gz\",\n",
+    "        \"colormap\": \"gray\",\n",
+    "        \"opacity\": 1.0,\n",
+    "        \"visible\": True,\n",
+    "    },\n",
+    "    {\n",
+    "        \"path\": DATA_FOLDER / \"fslt.nii.gz\",\n",
+    "        \"colormap\": \"redyell\",\n",
+    "        \"cal_min\": 0.05,\n",
+    "        \"cal_max\": 5.05,\n",
+    "        \"opacity\": 0.9,\n",
+    "        \"visible\": True,\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "nv.load_volumes(volumes)\n",
+    "\n",
+    "# Set the slice type to render (3D view)\n",
+    "nv.set_slice_type(SliceType.RENDER)\n",
+    "\n",
+    "# Set the clip plane\n",
+    "nv.set_clip_plane(0.15, 270, 0)\n",
+    "\n",
+    "# Set the render azimuth and elevation\n",
+    "nv.set_render_azimuth_elevation(45, 45)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3257ee16-f7aa-48c4-a191-95616a44a9db",
+   "metadata": {},
+   "source": [
+    "Create interactive checkbox"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9946de46-fff6-4b24-8de8-739f1bac8d32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a checkbox to toggle background masks overlays\n",
+    "background_masks_checkbox = widgets.Checkbox(\n",
+    "    value=False,\n",
+    "    description=\"Background masks overlay\",\n",
+    "    disabled=False,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Function to handle checkbox changes\n",
+    "def on_background_masks_change(change):\n",
+    "    \"\"\"Set background mask overlay.\"\"\"\n",
+    "    nv.background_masks_overlays = change.new\n",
+    "\n",
+    "\n",
+    "# Observe changes to the checkbox\n",
+    "background_masks_checkbox.observe(on_background_masks_change, names=\"value\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "930e164e-7f58-400e-8102-94502dce8076",
+   "metadata": {},
+   "source": [
+    "Display all"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79df762c-d512-4a00-a33a-a5fd6ca22840",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(background_masks_checkbox)\n",
+    "display(nv)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/mesh.4d.ipynb
+++ b/examples/mesh.4d.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "479d3a4f-9821-494c-8784-d1cbf85e91cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import ipyniivue\n",
+    "\n",
+    "# GitHub API URL for the base folder\n",
+    "BASE_API_URL = (\n",
+    "    \"https://api.github.com/repos/niivue/niivue/contents/packages/niivue/demos/images\"\n",
+    ")\n",
+    "DATA_FOLDER = Path(ipyniivue.__file__).parent / \"images\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "119c091d-8a98-4b0b-97c6-d5b724d67f80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download data for example\n",
+    "ipyniivue.download_dataset(\n",
+    "    f\"{BASE_API_URL}\",\n",
+    "    DATA_FOLDER,\n",
+    "    files=[\n",
+    "        \"Human.colin.Cerebral.R.VERY_INFLATED.71723.surf.gii\",\n",
+    "        \"Human.colin.R.FUNCTIONAL.71723.func.gii\",\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45ba4675-32cd-4a89-ab5e-33eec2597d26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display\n",
+    "\n",
+    "from ipyniivue import NiiVue, SliceType\n",
+    "\n",
+    "nv = NiiVue(\n",
+    "    show_3d_crosshair=True,\n",
+    "    back_color=(0.9, 0.9, 1, 1),\n",
+    ")\n",
+    "nv.set_slice_type(SliceType.RENDER)\n",
+    "\n",
+    "# Load meshes\n",
+    "mesh_layers = [\n",
+    "    {\n",
+    "        \"path\": DATA_FOLDER / \"Human.colin.R.FUNCTIONAL.71723.func.gii\",\n",
+    "        \"colormap\": \"rocket\",\n",
+    "        \"opacity\": 0.7,\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "meshes = [\n",
+    "    {\n",
+    "        \"path\": DATA_FOLDER / \"Human.colin.Cerebral.R.VERY_INFLATED.71723.surf.gii\",\n",
+    "        \"rgba255\": [255, 255, 255, 255],\n",
+    "        \"layers\": mesh_layers,\n",
+    "    },\n",
+    "]\n",
+    "nv.load_meshes(meshes)\n",
+    "\n",
+    "# Set the clip plane\n",
+    "nv.set_clip_plane(-0.1, 270, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44cffb51-66b6-4668-be46-78bd45ff9bfe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Timepoint Slider\n",
+    "slider_timepoint = widgets.IntSlider(min=0, max=1, value=0, description=\"Timepoint\")\n",
+    "\n",
+    "\n",
+    "def on_timepoint_change(change):\n",
+    "    \"\"\"Set mesh layer frame 4D.\"\"\"\n",
+    "    nv.set_mesh_layer_property(nv.meshes[0].id, 0, \"frame4D\", change[\"new\"])\n",
+    "\n",
+    "\n",
+    "slider_timepoint.observe(on_timepoint_change, names=\"value\")\n",
+    "\n",
+    "# Opacity Slider\n",
+    "slider_opacity = widgets.IntSlider(min=1, max=10, value=7, description=\"Opacity\")\n",
+    "\n",
+    "\n",
+    "def on_opacity_change(change):\n",
+    "    \"\"\"Set mesh layer opacity.\"\"\"\n",
+    "    nv.set_mesh_layer_property(nv.meshes[0].id, 0, \"opacity\", change[\"new\"] * 0.1)\n",
+    "\n",
+    "\n",
+    "slider_opacity.observe(on_opacity_change, names=\"value\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "475cf9fe-f1a6-4d87-b8a7-4d2e5995289f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shader_options = nv.mesh_shader_names()\n",
+    "\n",
+    "shader_dropdown = widgets.Dropdown(\n",
+    "    options=shader_options,\n",
+    "    value=\"Phong\",  # Default shader\n",
+    "    description=\"Shader:\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def on_shader_change(change):\n",
+    "    \"\"\"Set mesh layer shader.\"\"\"\n",
+    "    nv.set_mesh_shader(nv.meshes[0].id, change[\"new\"])\n",
+    "\n",
+    "\n",
+    "shader_dropdown.observe(on_shader_change, names=\"value\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3f74d15-aeaa-42fa-bf86-bf1a8c4758f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "controls = widgets.HBox([slider_timepoint, slider_opacity, shader_dropdown])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c89e658b-fd33-46f6-b74f-6ec47b25b514",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(controls)\n",
+    "display(nv)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/mesh_and_volume.ipynb
+++ b/examples/mesh_and_volume.ipynb
@@ -87,7 +87,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/mesh_layers.ipynb
+++ b/examples/mesh_layers.ipynb
@@ -117,7 +117,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/mosaic.ipynb
+++ b/examples/mosaic.ipynb
@@ -341,7 +341,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/on_event.ipynb
+++ b/examples/on_event.ipynb
@@ -138,7 +138,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/prototypes/meshes_(GIfTI, FreeSurfer, MZ3, OBJ, STL, legacy VTK).ipynb
+++ b/examples/prototypes/meshes_(GIfTI, FreeSurfer, MZ3, OBJ, STL, legacy VTK).ipynb
@@ -62,7 +62,32 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/examples/prototypes/torso_regions.ipynb
+++ b/examples/prototypes/torso_regions.ipynb
@@ -91,7 +91,32 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/examples/prototypes/trajectory.ipynb
+++ b/examples/prototypes/trajectory.ipynb
@@ -69,7 +69,32 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/examples/saving.ipynb
+++ b/examples/saving.ipynb
@@ -121,7 +121,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/sync_bidirectional.ipynb
+++ b/examples/sync_bidirectional.ipynb
@@ -93,7 +93,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/widgets.ipynb
+++ b/examples/widgets.ipynb
@@ -174,7 +174,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/js/mesh.ts
+++ b/js/mesh.ts
@@ -57,6 +57,19 @@ function setup_layer_property_listeners(
 		nv.updateGLVolume();
 	}
 
+	// other props
+	function colormap_invert_changed() {
+		layer.colormapInvert = layerModel.get("colormap_invert");
+		mesh.updateMesh(nv.gl);
+		nv.updateGLVolume();
+	}
+
+	function frame4D_changed() {
+		layer.frame4D = layerModel.get("frame4D");
+		mesh.updateMesh(nv.gl);
+		nv.updateGLVolume();
+	}
+
 	// Set up the event listeners
 	layerModel.on("change:opacity", opacity_changed);
 	layerModel.on("change:colormap", colormap_changed);
@@ -65,6 +78,9 @@ function setup_layer_property_listeners(
 	layerModel.on("change:cal_min", cal_min_changed);
 	layerModel.on("change:cal_max", cal_max_changed);
 	layerModel.on("change:outline_border", outline_border_changed);
+
+	layerModel.on("change:colormap_invert", colormap_invert_changed);
+	layerModel.on("change:frame4D", frame4D_changed);
 
 	// Return a cleanup function
 	return () => {
@@ -75,6 +91,9 @@ function setup_layer_property_listeners(
 		layerModel.off("change:cal_min", cal_min_changed);
 		layerModel.off("change:cal_max", cal_max_changed);
 		layerModel.off("change:outline_border", outline_border_changed);
+
+		layerModel.off("change:colormap_invert", colormap_invert_changed);
+		layerModel.off("change:frame4D", frame4D_changed);
 	};
 }
 
@@ -92,14 +111,22 @@ function setup_mesh_property_listeners(
 		mesh.updateMesh(nv.gl);
 		nv.updateGLVolume();
 	}
+
 	function rgba255_changed() {
 		mesh.rgba255 = new Uint8Array(mmodel.get("rgba255"));
 		mesh.updateMesh(nv.gl);
 		nv.updateGLVolume();
 	}
+
 	function visible_changed() {
 		mesh.visible = mmodel.get("visible");
 		mesh.updateMesh(nv.gl);
+		nv.updateGLVolume();
+	}
+
+	// other props
+	function colormap_invert_changed() {
+		mesh.colormapInvert = mmodel.get("colormap_invert");
 		nv.updateGLVolume();
 	}
 
@@ -107,11 +134,15 @@ function setup_mesh_property_listeners(
 	mmodel.on("change:rgba255", rgba255_changed);
 	mmodel.on("change:visible", visible_changed);
 
+	mmodel.on("change:colormap_invert", colormap_invert_changed);
+
 	// Return a function to remove the event listeners
 	return () => {
 		mmodel.off("change:opacity", opacity_changed);
 		mmodel.off("change:rgba255", rgba255_changed);
 		mmodel.off("change:visible", visible_changed);
+
+		mmodel.off("change:colormap_invert", colormap_invert_changed);
 	};
 }
 

--- a/js/types.ts
+++ b/js/types.ts
@@ -5,6 +5,17 @@ interface File {
 	data: DataView;
 }
 
+type ColorMap = {
+	R: number[];
+	G: number[];
+	B: number[];
+	A: number[];
+	I: number[];
+	min?: number;
+	max?: number;
+	labels?: string[];
+};
+
 export type VolumeModel = AnyModel<{
 	path: File;
 	id: string;
@@ -16,6 +27,8 @@ export type VolumeModel = AnyModel<{
 	cal_min?: number;
 	cal_max?: number;
 	frame4D: number;
+
+	colormap_invert: boolean;
 }>;
 
 export type MeshModel = AnyModel<{
@@ -26,6 +39,8 @@ export type MeshModel = AnyModel<{
 	opacity: number;
 	layers: Array<string>;
 	visible: boolean;
+
+	colormap_invert: boolean;
 }>;
 
 export type MeshLayerModel = AnyModel<{
@@ -38,6 +53,9 @@ export type MeshLayerModel = AnyModel<{
 	cal_min: number;
 	cal_max: number;
 	outline_border: number;
+
+	colormap_invert: boolean;
+	frame4D: number;
 }>;
 
 export type Model = AnyModel<{
@@ -46,31 +64,37 @@ export type Model = AnyModel<{
 	_volumes: Array<string>;
 	_meshes: Array<string>;
 	_opts: Record<string, unknown>;
+
+	background_masks_overlays: boolean;
 }>;
 
 // Custom message datas
-type SaveDocumentData = {
-	fileName: string;
-	compress: boolean;
-};
+type SaveDocumentData = [fileName: string, compress: boolean];
 
-type SaveHTMLData = {
-	fileName: string;
-	canvasId: string;
-};
+type SaveHTMLData = [fileName: string, canvasId: string];
 
-type SaveImageData = {
-	fileName: string;
-	saveDrawing: boolean;
-	indexVolume: number;
-};
+type SaveImageData = [
+	filename: string,
+	isSaveDrawing: boolean,
+	volumeByIndex: number,
+];
 
-type SaveSceneData = {
-	fileName: string;
-};
+type SaveSceneData = [fileName: string];
+
+type AddColormapData = [name: string, cmap: ColorMap];
+
+type SetGammaData = [gamma: number];
+
+type SetClipPlaneData = [clipPlane: number[]];
+
+type SetMeshShaderData = [meshId: string, shader: string];
 
 export type CustomMessagePayload =
 	| { type: "save_document"; data: SaveDocumentData }
 	| { type: "save_html"; data: SaveHTMLData }
 	| { type: "save_image"; data: SaveImageData }
-	| { type: "save_scene"; data: SaveSceneData };
+	| { type: "save_scene"; data: SaveSceneData }
+	| { type: "add_colormap"; data: AddColormapData }
+	| { type: "set_gamma"; data: SetGammaData }
+	| { type: "set_clip_plane"; data: SetClipPlaneData }
+	| { type: "set_mesh_shader"; data: SetMeshShaderData };

--- a/js/volume.ts
+++ b/js/volume.ts
@@ -15,24 +15,35 @@ function setup_volume_property_listeners(
 		volume.colorbarVisible = vmodel.get("colorbar_visible");
 		nv.updateGLVolume();
 	}
+
 	function cal_min_changed() {
 		volume.cal_min = vmodel.get("cal_min");
 		nv.updateGLVolume();
 	}
+
 	function cal_max_changed() {
 		volume.cal_max = vmodel.get("cal_max");
 		nv.updateGLVolume();
 	}
+
 	function colormap_changed() {
 		volume.colormap = vmodel.get("colormap");
 		nv.updateGLVolume();
 	}
+
 	function opacity_changed() {
 		volume.opacity = vmodel.get("opacity");
 		nv.updateGLVolume();
 	}
+
 	function frame4D_changed() {
 		volume.frame4D = vmodel.get("frame4D");
+		nv.updateGLVolume();
+	}
+
+	// other props
+	function colormap_invert_changed() {
+		volume.colormapInvert = vmodel.get("colormap_invert");
 		nv.updateGLVolume();
 	}
 
@@ -43,6 +54,8 @@ function setup_volume_property_listeners(
 	vmodel.on("change:opacity", opacity_changed);
 	vmodel.on("change:frame4D", frame4D_changed);
 
+	vmodel.on("change:colormap_invert", colormap_invert_changed);
+
 	return () => {
 		vmodel.off("change:colorbar_visible", colorbar_visible_changed);
 		vmodel.off("change:cal_min", cal_min_changed);
@@ -50,6 +63,8 @@ function setup_volume_property_listeners(
 		vmodel.off("change:colormap", colormap_changed);
 		vmodel.off("change:opacity", opacity_changed);
 		vmodel.off("change:frame4D", frame4D_changed);
+
+		vmodel.off("change:colormap_invert", colormap_invert_changed);
 	};
 }
 

--- a/js/widget.ts
+++ b/js/widget.ts
@@ -33,33 +33,62 @@ function attachModelEventHandlers(
 		nv.updateGLVolume();
 	});
 
+	// Other nv prop changes
+	model.on("change:background_masks_overlays", () => {
+		const backgroundMasksOverlays = model.get("background_masks_overlays");
+		if (typeof backgroundMasksOverlays === "boolean") {
+			nv.backgroundMasksOverlays = Number(backgroundMasksOverlays);
+			nv.updateGLVolume();
+		}
+	});
+
 	// Handle any message directions from the nv object.
 	model.on("msg:custom", (payload: CustomMessagePayload) => {
 		const { type, data } = payload;
 		switch (type) {
 			case "save_document": {
-				const { fileName, compress } = data;
+				const [fileName, compress] = data;
 				nv.saveDocument(fileName, compress);
 				break;
 			}
 			case "save_html": {
-				const { fileName, canvasId } = data;
-				// Note: currently fails as esm is inaccesbile.
+				const [fileName, canvasId] = data;
+				// Note: currently fails as esm is inaccessible.
 				// nv.saveHTML(fileName, canvasId, esm);
 				break;
 			}
 			case "save_image": {
-				const { fileName, saveDrawing, indexVolume } = data;
+				const [filename, isSaveDrawing, volumeByIndex] = data;
 				nv.saveImage({
-					filename: fileName,
-					isSaveDrawing: saveDrawing,
-					volumeByIndex: indexVolume,
+					filename,
+					isSaveDrawing,
+					volumeByIndex,
 				});
 				break;
 			}
 			case "save_scene": {
-				const { fileName } = data;
+				const [fileName] = data;
 				nv.saveScene(fileName);
+				break;
+			}
+			case "add_colormap": {
+				const [name, cmap] = data;
+				nv.addColormap(name, cmap);
+				break;
+			}
+			case "set_gamma": {
+				const [gamma] = data;
+				nv.setGamma(gamma);
+				break;
+			}
+			case "set_clip_plane": {
+				const [clipPlane] = data;
+				nv.setClipPlane(clipPlane);
+				break;
+			}
+			case "set_mesh_shader": {
+				const [meshId, shader] = data;
+				nv.setMeshShader(meshId, shader);
 				break;
 			}
 		}
@@ -370,6 +399,8 @@ export default {
 			model.off("change:_opts");
 			model.off("change:height");
 			model.off("msg:custom");
+
+			model.off("change:background_masks_overlays");
 
 			// remove the nv instance
 			nvMap.delete(model.get("id"));

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
 	"type": "module",
 	"scripts": {
-		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "esbuild js/widget.ts --minify --external:fs --external:path --format=esm --bundle --outdir=src/ipyniivue/static",
+		"dev": "node build.js --watch",
+		"build": "node build.js",
 		"lint": "biome ci .",
 		"fix": "biome check --fix .",
 		"typecheck": "tsc"

--- a/scripts/generate_options_mixin.py
+++ b/scripts/generate_options_mixin.py
@@ -7,7 +7,8 @@ import typing
 from ipyniivue.constants import (
     _SNAKE_TO_CAMEL_OVERRIDES,
     DragMode,
-    MuliplanarType,
+    MultiplanarType,
+    ShowRender,
     SliceType,
 )
 
@@ -35,10 +36,12 @@ def type_hint(value: typing.Any):
         return "dict"
     elif isinstance(value, SliceType):
         return "SliceType"
-    elif isinstance(value, MuliplanarType):
-        return "MuliplanarType"
+    elif isinstance(value, MultiplanarType):
+        return "MultiplanarType"
     elif isinstance(value, DragMode):
         return "DragMode"
+    elif isinstance(value, ShowRender):
+        return "ShowRender"
     else:
         return "typing.Any"
 
@@ -50,10 +53,12 @@ def get_value(value: typing.Any):
         return 'float("nan")'
     if isinstance(value, SliceType):
         return f"SliceType.{value.name}"
-    if isinstance(value, MuliplanarType):
-        return f"MuliplanarType.{value.name}"
+    if isinstance(value, MultiplanarType):
+        return f"MultiplanarType.{value.name}"
     if isinstance(value, DragMode):
         return f"DragMode.{value.name}"
+    if isinstance(value, ShowRender):
+        return f"ShowRender.{value.name}"
     if isinstance(value, str):
         # double quote
         return f'"{value}"'
@@ -71,7 +76,7 @@ def generate_mixin(options: dict[str, typing.Any]):
         "",
         "import typing",
         "",
-        "from .constants import DragMode, MuliplanarType, SliceType",
+        "from .constants import DragMode, MultiplanarType, ShowRender, SliceType",
         "",
         '__all__ = ["OptionsMixin"]',
         "",
@@ -129,6 +134,7 @@ if __name__ == "__main__":
         "isOrientCube": False,
         "multiplanarPadPixels": 0,
         "multiplanarForceRender": False,
+        "multiplanarShowRender": ShowRender.AUTO,
         "isRadiologicalConvention": False,
         "meshThicknessOn2D": float("inf"),
         "dragMode": DragMode.CONTRAST,
@@ -157,7 +163,7 @@ if __name__ == "__main__":
         "showLegend": True,
         "legendBackgroundColor": (0.3, 0.3, 0.3, 0.5),
         "legendTextColor": (1.0, 1.0, 1.0, 1.0),
-        "multiplanarLayout": MuliplanarType.AUTO,
+        "multiplanarLayout": MultiplanarType.AUTO,
         "renderOverlayBlend": 1.0,
         "sliceMosaicString": "",
         "centerMosaic": False,

--- a/src/ipyniivue/__init__.py
+++ b/src/ipyniivue/__init__.py
@@ -2,7 +2,7 @@
 
 import importlib.metadata
 
-from .constants import DragMode, MuliplanarType, SliceType  # noqa: F401
+from .constants import DragMode, MultiplanarType, ShowRender, SliceType  # noqa: F401
 from .download_dataset import download_dataset  # noqa: F401
 from .widget import (  # noqa: F401
     Drawing,

--- a/src/ipyniivue/constants.py
+++ b/src/ipyniivue/constants.py
@@ -9,19 +9,27 @@ import enum
 
 __all__ = [
     "DragMode",
-    "MuliplanarType",
+    "MultiplanarType",
     "SliceType",
 ]
 
 
 class SliceType(enum.Enum):
     """
-    Defines the number value equivalents for each SliceType of a NiiVue instance.
+    An enumeration of slice types for NiiVue instances.
 
-    Parameters
-    ----------
-    enum.Enum
-        A new enumeration for this class to store members.
+    Members
+    -------
+    AXIAL : int
+        Axial slice type (value 0).
+    CORONAL : int
+        Coronal slice type (value 1).
+    SAGITTAL : int
+        Sagittal slice type (value 2).
+    MULTIPLANAR : int
+        Multiplanar view type (value 3).
+    RENDER : int
+        Render view type (value 4).
     """
 
     AXIAL = 0
@@ -33,12 +41,16 @@ class SliceType(enum.Enum):
 
 class DragMode(enum.Enum):
     """
-    Defines the number value equivalents for each DragMode of a NiiVue instance.
+    An enumeration of drag modes for NiiVue instances.
 
-    Parameters
-    ----------
-    enum.Enum
-        A new enumeration for this class to store members.
+    Members
+    -------
+    CONTRAST : int
+        Contrast adjustment mode (value 1).
+    MEASUREMENT : int
+        Measurement mode for taking measurements (value 2).
+    PAN : int
+        Pan mode for moving around the image (value 3).
     """
 
     CONTRAST = 1
@@ -46,20 +58,45 @@ class DragMode(enum.Enum):
     PAN = 3
 
 
-class MuliplanarType(enum.Enum):
+class MultiplanarType(enum.Enum):
     """
-    Defines the number value equivalents for each MultiplanarType of a NiiVue instance.
+    An enumeration of multiplanar types for NiiVue instances.
 
-    Parameters
-    ----------
-    enum.Enum
-        A new enumeration for this class to store members.
+    Members
+    -------
+    AUTO : int
+        Automatic multiplanar type (value 0).
+    COLUMN : int
+        Column multiplanar type (value 1).
+    GRID : int
+        Grid multiplanar type (value 2).
+    ROW : int
+        Row multiplanar type (value 3).
     """
 
     AUTO = 0
     COLUMN = 1
     GRID = 2
     ROW = 3
+
+
+class ShowRender(enum.Enum):
+    """
+    An enumeration for specifying when to show rendering in NiiVue instances.
+
+    Members
+    -------
+    NEVER : int
+        Never show rendering (value 0).
+    ALWAYS : int
+        Always show rendering (value 1).
+    AUTO : int
+        Automatically determine whether to show rendering (value 2).
+    """
+
+    NEVER = 0
+    ALWAYS = 1
+    AUTO = 2
 
 
 _SNAKE_TO_CAMEL_OVERRIDES = {

--- a/src/ipyniivue/options_mixin.py
+++ b/src/ipyniivue/options_mixin.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import typing
 
-from .constants import DragMode, MuliplanarType, SliceType
+from .constants import DragMode, MultiplanarType, ShowRender, SliceType
 
 __all__ = ["OptionsMixin"]
 
@@ -274,6 +274,16 @@ class OptionsMixin:
     def multiplanar_force_render(self, value: bool):
         """Automatically generated property. See generate_options_mixin.py."""
         self._opts = {**self._opts, "multiplanarForceRender": value}
+
+    @property
+    def multiplanar_show_render(self) -> ShowRender:
+        """Automatically generated property. See generate_options_mixin.py."""
+        return self._opts.get("multiplanarShowRender", ShowRender.AUTO)
+
+    @multiplanar_show_render.setter
+    def multiplanar_show_render(self, value: ShowRender):
+        """Automatically generated property. See generate_options_mixin.py."""
+        self._opts = {**self._opts, "multiplanarShowRender": value}
 
     @property
     def is_radiological_convention(self) -> bool:
@@ -556,12 +566,12 @@ class OptionsMixin:
         self._opts = {**self._opts, "legendTextColor": value}
 
     @property
-    def multiplanar_layout(self) -> MuliplanarType:
+    def multiplanar_layout(self) -> MultiplanarType:
         """Automatically generated property. See generate_options_mixin.py."""
-        return self._opts.get("multiplanarLayout", MuliplanarType.AUTO)
+        return self._opts.get("multiplanarLayout", MultiplanarType.AUTO)
 
     @multiplanar_layout.setter
-    def multiplanar_layout(self, value: MuliplanarType):
+    def multiplanar_layout(self, value: MultiplanarType):
         """Automatically generated property. See generate_options_mixin.py."""
         self._opts = {**self._opts, "multiplanarLayout": value}
 

--- a/src/ipyniivue/widget.py
+++ b/src/ipyniivue/widget.py
@@ -1233,7 +1233,7 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
         Parameters
         ----------
         callback : callable
-            A function that takes one argument—a ``dict`` with the following keys:
+            A function that takes one argument - a ``dict`` with the following keys:
 
             - **mm3** (float): The segmented volume in cubic millimeters.
             - **mL** (float): The segmented volume in milliliters.
@@ -1270,7 +1270,7 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
         Parameters
         ----------
         callback : callable
-            A function that takes one argument—a list of numbers representing the
+            A function that takes one argument - a list of numbers representing the
             clip plane.
         remove : bool, optional
             If ``True``, remove the callback. Defaults to ``False``.
@@ -1284,11 +1284,10 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_clip_plane_change
             def my_callback(clip_plane):
                 with out:
                     print('Clip plane changed:', clip_plane)
-
-            nv.on_clip_plane_change(my_callback)
 
         """
         self._register_callback("clip_plane_change", callback, remove=remove)
@@ -1303,7 +1302,7 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
         Parameters
         ----------
         callback : callable
-            A function that takes one argument—a ``dict`` representing the loaded
+            A function that takes one argument - a ``dict`` representing the loaded
             document with the following keys:
 
             - **title** (str): The title of the loaded document.
@@ -1323,6 +1322,7 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_document_loaded
             def my_callback(document):
                 with out:
                     print('Document loaded:')
@@ -1330,8 +1330,6 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
                     print('Options:', document['opts'])
                     print('Volumes:', document['volumes'])
                     print('Meshes:', document['meshes'])
-
-            nv.on_document_loaded(my_callback)
 
         """
         self._register_callback("document_loaded", callback, remove=remove)
@@ -1345,7 +1343,7 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
         Parameters
         ----------
         callback : callable
-            A function that takes one argument—a ``Volume`` object.
+            A function that takes one argument - a ``Volume`` object.
         remove : bool, optional
             If ``True``, remove the callback. Defaults to ``False``.
 
@@ -1358,11 +1356,10 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_image_loaded
             def my_callback(volume):
                 with out:
                     print('Image loaded:', volume.id)
-
-            nv.on_image_loaded(my_callback)
 
         """
         self._register_callback("image_loaded", callback, remove=remove)
@@ -1377,7 +1374,7 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
         Parameters
         ----------
         callback : callable
-            A function that takes one argument—a ``dict`` containing drag release
+            A function that takes one argument - a ``dict`` containing drag release
             parameters with the following keys:
 
             - **frac_start** (list of float): Starting fractional coordinates
@@ -1409,11 +1406,10 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_drag_release
             def my_callback(params):
                 with out:
                     print('Drag release event:', params)
-
-            nv.on_drag_release(my_callback)
 
         """
         self._register_callback("drag_release", callback, remove=remove)
@@ -1445,13 +1441,12 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_frame_change
             def my_callback(volume, frame_index):
                 with out:
                     print('Frame changed')
                     print('Volume:', volume)
                     print('Frame index:', frame_index)
-
-            nv.on_frame_change(my_callback)
 
         """
         self._register_callback("frame_change", callback, remove=remove)
@@ -1466,7 +1461,7 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
         Parameters
         ----------
         callback : callable
-            A function that takes one argument—a ``Volume`` object.
+            A function that takes one argument - a ``Volume`` object.
         remove : bool, optional
             If ``True``, remove the callback. Defaults to ``False``.
 
@@ -1479,11 +1474,10 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_intensity_change
             def my_callback(volume):
                 with out:
                     print('Intensity changed for volume:', volume)
-
-            nv.on_intensity_change(my_callback)
 
         """
         self._register_callback("intensity_change", callback, remove=remove)
@@ -1498,8 +1492,8 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
         Parameters
         ----------
         callback : callable
-            A function that takes one argument—a ``dict`` containing the new
-            location data—with the following keys:
+            A function that takes one argument - a ``dict`` containing the new
+            location data - with the following keys:
 
             - **ax_cor_sag** (int): The view index where the location changed.
             - **frac** (list of float): The fractional coordinates ``[X, Y, Z]``
@@ -1524,11 +1518,10 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_location_change
             def my_callback(location):
                 with out:
                     print('Location changed', location)
-
-            nv.on_location_change(my_callback)
 
         """
         self._register_callback("location_change", callback, remove=remove)
@@ -1570,14 +1563,13 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_mesh_added_from_url
             def my_callback(mesh_options, mesh):
                 with out:
                     print('Mesh added from URL')
                     print('URL:', mesh_options['url'])
                     print('Headers:', mesh_options['headers'])
                     print('Mesh ID:', mesh['id'])
-
-            nv.on_mesh_added_from_url(my_callback)
 
         """
         self._register_callback("mesh_added_from_url", callback, remove=remove)
@@ -1591,7 +1583,7 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
         Parameters
         ----------
         callback : callable
-            A function that takes one argument—the loaded mesh (``Mesh`` object).
+            A function that takes one argument - the loaded mesh (``Mesh`` object).
         remove : bool, optional
             If ``True``, remove the callback. Defaults to ``False``.
 
@@ -1604,11 +1596,10 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_mesh_loaded
             def my_callback(mesh):
                 with out:
                     print('Mesh loaded', mesh)
-
-            nv.on_mesh_loaded(my_callback)
 
         """
         self._register_callback("mesh_loaded", callback, remove=remove)
@@ -1622,7 +1613,7 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
         Parameters
         ----------
         callback : callable
-            A function that takes one argument—a ``dict`` containing mouse event data
+            A function that takes one argument - a ``dict`` containing mouse event data
             with the following keys:
 
             - **is_dragging** (bool): Indicates if a drag action is in progress
@@ -1644,11 +1635,10 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_mouse_up
             def my_callback(data):
                 with out:
                     print('Mouse button released', data)
-
-            nv.on_mouse_up(my_callback)
 
         """
         self._register_callback("mouse_up", callback, remove=remove)
@@ -1724,14 +1714,13 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_volume_added_from_url
             def my_callback(image_options, volume):
                 with out:
                     print('Volume added from URL')
                     print('URL:', image_options['url'])
                     print('Headers:', image_options['headers'])
                     print('Volume ID:', volume['id'])
-
-            nv.on_volume_added_from_url(my_callback)
 
         """
         self._register_callback("volume_added_from_url", callback, remove=remove)
@@ -1760,11 +1749,10 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
             out = Output()
             display(out)
 
+            @nv.on_volume_updated
             def my_callback():
                 with out:
                     print('Volumes updated')
-
-            nv.on_volume_updated(my_callback)
 
         """
         self._register_callback("volume_updated", callback, remove=remove)

--- a/src/ipyniivue/widget.py
+++ b/src/ipyniivue/widget.py
@@ -15,7 +15,7 @@ import ipywidgets
 import traitlets as t
 from ipywidgets import CallbackDispatcher
 
-from .constants import _SNAKE_TO_CAMEL_OVERRIDES
+from .constants import _SNAKE_TO_CAMEL_OVERRIDES, SliceType
 from .options_mixin import OptionsMixin
 from .utils import (
     file_serializer,
@@ -62,6 +62,17 @@ class MeshLayer(ipywidgets.Widget):
     cal_min = t.Float(None, allow_none=True).tag(sync=True)
     cal_max = t.Float(None, allow_none=True).tag(sync=True)
     outline_border = t.Int(0).tag(sync=True)
+
+    # other properties that aren't in init
+    colormap_invert = t.Bool(False).tag(sync=True)
+    frame4D = t.Int(0).tag(sync=True)
+
+    def __init__(self, **kwargs):
+        if "colormap_invert" in kwargs:
+            kwargs.pop("colormap_invert")
+        if "frame4D" in kwargs:
+            kwargs.pop("frame4D")
+        super().__init__(**kwargs)
 
     @t.validate("path")
     def _validate_path(self, proposal):
@@ -113,7 +124,12 @@ class Mesh(ipywidgets.Widget):
         sync=True, **ipywidgets.widget_serialization
     )
 
+    # other properties that aren't in init
+    colormap_invert = t.Bool(False).tag(sync=True)
+
     def __init__(self, **kwargs):
+        if "colormap_invert" in kwargs:
+            kwargs.pop("colormap_invert")
         layers_data = kwargs.pop("layers", [])
         super().__init__(**kwargs)
         self.layers = [MeshLayer(**layer_data) for layer_data in layers_data]
@@ -170,6 +186,14 @@ class Volume(ipywidgets.Widget):
     cal_min = t.Float(None, allow_none=True).tag(sync=True)
     cal_max = t.Float(None, allow_none=True).tag(sync=True)
     frame4D = t.Int(0).tag(sync=True)
+
+    # other properties that aren't in init
+    colormap_invert = t.Bool(False).tag(sync=True)
+
+    def __init__(self, **kwargs):
+        if "colormap_invert" in kwargs:
+            kwargs.pop("colormap_invert")
+        super().__init__(**kwargs)
 
     @t.validate("path")
     def _validate_path(self, proposal):
@@ -249,6 +273,9 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
     _meshes = t.List(t.Instance(Mesh), default_value=[]).tag(
         sync=True, **ipywidgets.widget_serialization
     )
+
+    # other props
+    background_masks_overlays = t.Bool(False).tag(sync=True)
 
     def __init__(self, height: int = 300, **options):  # noqa: D417
         r"""
@@ -545,6 +572,10 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
         """
         return list(self._meshes)
 
+    """
+    Other functions
+    """
+
     def save_document(self, file_name: str = "document.nvd", compress: bool = True):
         """
         Save the entire scene with settings as a document.
@@ -701,6 +732,455 @@ class NiiVue(OptionsMixin, anywidget.AnyWidget):
 
         layer = mesh.layers[layer_index]
         setattr(layer, attribute, value)
+
+    def colormaps(self):
+        """Retrieve the list of available colormap names.
+
+        Returns
+        -------
+        list of str
+            A list containing the names of all available colormaps
+
+        Examples
+        --------
+        ::
+
+            colormaps = nv.colormaps()
+        """
+        fallback_colormaps = [
+            "actc",
+            "afni_blues_inv",
+            "afni_reds_inv",
+            "batlow",
+            "bcgwhw",
+            "bcgwhw_dark",
+            "blue",
+            "blue2cyan",
+            "blue2magenta",
+            "blue2red",
+            "bluegrn",
+            "bone",
+            "bronze",
+            "cet_l17",
+            "cividis",
+            "cool",
+            "copper",
+            "copper2",
+            "ct_airways",
+            "ct_artery",
+            "ct_bones",
+            "ct_brain",
+            "ct_brain_gray",
+            "ct_cardiac",
+            "ct_head",
+            "ct_kidneys",
+            "ct_liver",
+            "ct_muscles",
+            "ct_scalp",
+            "ct_skull",
+            "ct_soft",
+            "ct_soft_tissue",
+            "ct_surface",
+            "ct_vessels",
+            "ct_w_contrast",
+            "cubehelix",
+            "electric_blue",
+            "freesurfer",
+            "ge_color",
+            "gold",
+            "gray",
+            "green",
+            "green2cyan",
+            "green2orange",
+            "hot",
+            "hotiron",
+            "hsv",
+            "inferno",
+            "jet",
+            "kry",
+            "linspecer",
+            "lipari",
+            "magma",
+            "mako",
+            "navia",
+            "nih",
+            "plasma",
+            "random",
+            "red",
+            "redyell",
+            "rocket",
+            "roi_i256",
+            "surface",
+            "thermal",
+            "turbo",
+            "violet",
+            "viridis",
+            "warm",
+            "winter",
+            "x_rain",
+        ]
+        colormaps_path = pathlib.Path(__file__).parent / "static" / "colormaps.txt"
+        try:
+            with open(colormaps_path) as f:
+                colormaps_list = f.read().splitlines()
+        except FileNotFoundError:
+            return fallback_colormaps
+
+        return colormaps_list
+
+    def add_colormap(self, name: str, color_map: dict):
+        """Add a colormap to the widget.
+
+        Parameters
+        ----------
+        name : str
+            The name of the colormap.
+        color_map : dict
+            A dictionary containing the colormap information.
+            It must have the following keys:
+
+            **Required keys**:
+                - `'R'`: list of numbers
+                - `'G'`: list of numbers
+                - `'B'`: list of numbers
+                - `'A'`: list of numbers
+                - `'I'`: list of numbers
+
+            **Optional keys**:
+                - `'min'`: number
+                - `'max'`: number
+                - `'labels'`: list of strings
+
+            All the `'R'`, `'G'`, `'B'`, `'A'`, `'I'` lists must have the same length.
+
+        Raises
+        ------
+        ValueError
+            If the colormap does not meet the required format.
+        TypeError
+            If the colormap values are not of the correct type.
+
+        Examples
+        --------
+        ::
+
+            nv.add_colormap("custom_color_map", {
+                "R": [0, 255, 0],
+                "G": [0, 0, 255],
+                "B": [0, 0, 0],
+                "A": [0, 64, 64],
+                "I": [0, 85, 255]
+            })
+            nv.set_colormap(nv.volumes[0].id, "custom_color_map")
+        """
+        # Validate that required keys are present and are lists of numbers
+        required_keys = ["R", "G", "B", "A", "I"]
+        for key in required_keys:
+            if key not in color_map:
+                raise ValueError(f"ColorMap must include required key '{key}'")
+            if not isinstance(color_map[key], list):
+                raise TypeError(f"ColorMap key '{key}' must be a list")
+            if not all(isinstance(x, (int, float)) for x in color_map[key]):
+                raise TypeError(f"All elements in ColorMap key '{key}' must be numbers")
+
+        # Check that all required lists have the same length
+        lengths = [len(color_map[key]) for key in required_keys]
+        if len(set(lengths)) != 1:
+            raise ValueError(
+                "All 'R', 'G', 'B', 'A', 'I' lists must have the same length"
+            )
+
+        # Validate optional keys
+        if "min" in color_map and not isinstance(color_map["min"], (int, float)):
+            raise TypeError("ColorMap 'min' must be a number")
+
+        if "max" in color_map and not isinstance(color_map["max"], (int, float)):
+            raise TypeError("ColorMap 'max' must be a number")
+
+        if "labels" in color_map:
+            if not isinstance(color_map["labels"], list):
+                raise TypeError("ColorMap 'labels' must be a list of strings")
+            if not all(isinstance(label, str) for label in color_map["labels"]):
+                raise TypeError("All elements in ColorMap 'labels' must be strings")
+            if len(color_map["labels"]) != lengths[0]:
+                raise ValueError(
+                    "ColorMap 'labels' must have the same length "
+                    "as 'R', 'G', 'B', 'A', 'I' lists"
+                )
+
+        # Send the colormap to the frontend
+        self.send({"type": "add_colormap", "data": [name, color_map]})
+
+    def set_colormap(self, imageID: str, colormap: str):
+        """Set the colormap for a volume.
+
+        Parameters
+        ----------
+        imageID : str
+            The ID of the volume.
+        colormap : str
+            The name of the colormap to set.
+
+        Raises
+        ------
+        ValueError
+            If the volume with the given ID is not found.
+
+        Examples
+        --------
+        ::
+
+            nv.set_colormap(nv.volumes[0].id, "green2cyan")
+        """
+        idx = self.get_volume_index_by_id(imageID)
+        if idx != -1:
+            self._volumes[idx].colormap = colormap
+        else:
+            raise ValueError(f"Volume with ID '{imageID}' not found")
+
+    def set_selection_box_color(self, color: tuple):
+        """Set the selection box color.
+
+        Parameters
+        ----------
+        color : tuple of floats
+            An RGBA array with values ranging from 0 to 1.
+
+        Raises
+        ------
+        ValueError
+            If the color is not a list of four numeric values.
+
+        Examples
+        --------
+        ::
+
+            nv.set_selection_box_color((0, 1, 0, 0.7))
+        """
+        if not isinstance(color, (list, tuple)) or len(color) != 4:
+            raise ValueError(
+                "Color must be a list or tuple of four numeric values (RGBA)."
+            )
+        if not all(isinstance(c, (int, float)) and 0 <= c <= 1 for c in color):
+            raise ValueError("Each color component must be a number between 0 and 1.")
+
+        self.selection_box_color = tuple(color)
+
+    def set_crosshair_color(self, color: tuple):
+        """Set the crosshair and colorbar outline color.
+
+        Parameters
+        ----------
+        color : tuple of floats
+            An RGBA array with values ranging from 0 to 1.
+
+        Raises
+        ------
+        ValueError
+            If the color is not a list of four numeric values.
+
+        Examples
+        --------
+        ::
+
+            nv.set_crosshair_color((0, 1, 0, 1))
+        """
+        if not isinstance(color, (list, tuple)) or len(color) != 4:
+            raise ValueError(
+                "Color must be a list or tuple of four numeric values (RGBA)."
+            )
+        if not all(isinstance(c, (int, float)) and 0 <= c <= 1 for c in color):
+            raise ValueError("Each color component must be a number between 0 and 1.")
+
+        self.crosshair_color = tuple(color)
+
+    def set_crosshair_width(self, width: int):
+        """Set the crosshair width.
+
+        Parameters
+        ----------
+        width : int
+            The width of the crosshair in pixels.
+
+        Examples
+        --------
+        ::
+
+            nv.set_crosshair_width(3)
+        """
+        self.crosshair_width = width
+
+    def set_gamma(self, gamma: float = 1.0):
+        """Adjust screen gamma.
+
+        Parameters
+        ----------
+        gamma : float
+            Selects luminance
+
+        Raises
+        ------
+        TypeError
+            If gamma is not a number
+
+        Examples
+        --------
+        ::
+
+            nv.set_gamma(3.0)
+        """
+        if not isinstance(gamma, (int, float)):
+            raise TypeError("gamma must be a number")
+
+        self.send({"type": "set_gamma", "data": [gamma]})
+
+    def set_slice_type(self, slice_type: SliceType):
+        """Set the type of slice display.
+
+        Parameters
+        ----------
+        slice_type : SliceType
+            The type of slice display.
+
+        Raises
+        ------
+        TypeError
+            If slice_type is not a valid SliceType.
+
+        Examples
+        --------
+        ::
+
+            nv.set_slice_type(SliceType.AXIAL)
+        """
+        if slice_type not in SliceType:
+            raise TypeError("slice_type must be a valid SliceType")
+
+        self.slice_type = slice_type
+
+    def set_clip_plane(self, depth: float, azimuth: float, elevation: float):
+        """Update the clip plane orientation in 3D view mode.
+
+        Parameters
+        ----------
+        depth : float
+            distance of clip plane from the center of the volume
+        azimuth : float
+            camera position in degrees around the object
+        elevation : float
+            camera height in degrees
+
+        Raises
+        ------
+        TypeError
+            If any of the inputs are not a number.
+
+        Examples
+        --------
+        ::
+
+            nv.set_clip_plane(2.0, 42.0, 42.0)
+        """
+        # Verify that all inputs are numeric types
+        if not all(isinstance(x, (int, float)) for x in [depth, azimuth, elevation]):
+            raise TypeError("depth, azimuth, and elevation must all be numeric values.")
+
+        self.send({"type": "set_clip_plane", "data": [depth, azimuth, elevation]})
+
+    def set_render_azimuth_elevation(self, azimuth: float, elevation: float):
+        """Set the rotation of the 3D render view.
+
+        Parameters
+        ----------
+        azimuth : float
+            The azimuth angle in degrees around the object.
+        elevation : float
+            The elevation angle in degrees.
+
+        Raises
+        ------
+        TypeError
+            If azimuth or elevation is not a number.
+
+        Examples
+        --------
+        ::
+
+            nv.set_render_azimuth_elevation(45, 15)
+        """
+        if not isinstance(azimuth, (int, float)):
+            raise TypeError("Azimuth must be a number.")
+        if not isinstance(elevation, (int, float)):
+            raise TypeError("Elevation must be a number.")
+        self.send(
+            {"type": "set_render_azimuth_elevation", "data": [azimuth, elevation]}
+        )
+
+    def set_mesh_shader(self, mesh_id: str, mesh_shader: str):
+        """Set the shader for a mesh.
+
+        Parameters
+        ----------
+        mesh_id : str
+            Identifier of the mesh to change (mesh id).
+        mesh_shader : str
+            The name of the shader to set.
+
+        Raises
+        ------
+        ValueError
+            If the mesh is not found.
+
+        Examples
+        --------
+        ::
+
+            nv.set_mesh_shader(nv.meshes[0].id, 'toon')
+        """
+        idx = self.get_mesh_index_by_id(mesh_id)
+        if idx == -1:
+            raise ValueError(f"Mesh with id '{mesh_id}' not found.")
+
+        self.send({"type": "set_mesh_shader", "data": [mesh_id, mesh_shader]})
+
+    def mesh_shader_names(self):
+        """Retrieve the list of available mesh shader names.
+
+        Returns
+        -------
+        list of str
+            A list containing the names of all available mesh shader names
+
+        Examples
+        --------
+        ::
+
+            shaders = nv.mesh_shader_names()
+        """
+        fallback_shader_names = [
+            "Crevice",
+            "Diffuse",
+            "Edge",
+            "Flat",
+            "Harmonic",
+            "Hemispheric",
+            "Matcap",
+            "Matte",
+            "Outline",
+            "Phong",
+            "Specular",
+            "Toon",
+        ]
+        shader_names_path = (
+            pathlib.Path(__file__).parent / "static" / "meshShaderNames.txt"
+        )
+        try:
+            with open(shader_names_path) as f:
+                shader_names_list = f.read().splitlines()
+        except FileNotFoundError:
+            return fallback_shader_names
+
+        return shader_names_list
 
     """
     Custom event callbacks


### PR DESCRIPTION
In order to support colormaps, colormaps.mesh, mask, and mesh.4d notebooks, the following properties + methods were added:

MeshLayer props:
- frame4D
- colormap_invert

Mesh props:
- colormap_invert

Volume props:
- colormap_invert

NiiVue props:
- background_masks_overlays

NiiVue.options props:
- multiplanar_show_render

Enums in constants.py
- ShowRender

Methods:
- save_scene
- get_volume_index_by_id
- get_mesh_index_by_id
- colormaps
- add_colormap
- set_colormap
- set_selection_box_color
- set_crosshair_color
- set_crosshair_width
- set_gamma
- set_slice_type
- set_mesh_layer_property
- set_clip_plane
- set_render_azimuth_elevation
- set_mesh_shader
- mesh_shader_names

NPM build plugins:
- generate-colormaps (generate src/ipyniivue/static/colormaps.txt) (used in nv.colormaps() method)
- generate-shader-names (generate src/ipyniivue/static/meshShaderNames.txt) (used in nv.mesh_shader_names() method)