### PR TITLE
Fix thumbnail generation on CI action runner

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -47,6 +47,21 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      # Cache Playwright browsers to speed subsequent runs
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            playwright-browsers-${{ runner.os }}-
+
+      # Ensure Playwright downloads browser executables (must run after npm ci)
+      - name: Install Playwright browsers
+        run: |
+          # install system deps + browsers on ubuntu; --with-deps tries to install native deps too
+          npx playwright install --with-deps
+
       # Generate the gallery HTML using the Hatch python that contains nbconvert.
       - name: Generate gallery HTML (uses Hatch python)
         run: |


### PR DESCRIPTION
A Playwright browser is used to generate the thumbnail. Update the CI action to install Playwright browser.